### PR TITLE
RINGUS-68 fix: 프로필 등록 로직 변경

### DIFF
--- a/src/user/components/profile/mentee/MenteeProfile.tsx
+++ b/src/user/components/profile/mentee/MenteeProfile.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { GlobalButton } from '@/global/ui/GlobalButton';
 import { AuthInputBox } from '@/auth/components/AuthInputBox';
 import { uploadProfileImage } from '@/user/api/profileApi';
@@ -27,6 +27,12 @@ const MenteeProfile = ({
   const [successMessage, setSuccessMessage] = useState<string | undefined>(
     undefined,
   );
+
+  useEffect(() => {
+    if (menteeData.nickname.trim().length > 0 && !nicknameError) {
+      setIsNicknameValid(true);
+    }
+  }, [menteeData.nickname, nicknameError]);
 
   // 프로필 이미지 선택 후 API 요청하여 업로드
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/user/components/profile/mentor/MentorProfile1.tsx
+++ b/src/user/components/profile/mentor/MentorProfile1.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { GlobalButton } from '@/global/ui/GlobalButton';
 import { AuthInputBox } from '@/auth/components/AuthInputBox';
 import { MentorProfileData } from '@/user/types/profileTypes';
@@ -35,6 +35,12 @@ const MentorProfile1 = ({
   const [successMessage, setSuccessMessage] = useState<string | undefined>(
     undefined,
   );
+
+  useEffect(() => {
+    if (mentorData.nickname.trim().length > 0 && !nicknameError) {
+      setIsNicknameValid(true);
+    }
+  }, [mentorData.nickname, nicknameError]);
 
   // 프로필 이미지 선택 후 API 요청하여 업로드
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/user/components/profile/mentor/MentorProfile2.tsx
+++ b/src/user/components/profile/mentor/MentorProfile2.tsx
@@ -16,10 +16,14 @@ const MentorProfile2 = ({
   onNext,
 }: MentorProfile2Props) => {
   // 전체 입력 필드 유효성 체크 (자기소개 + 멘토링 분야)
+  const isTimezoneValid =
+    mentorData.timezone.days.length > 0 && // 최소 한 개의 요일 선택
+    mentorData.timezone.startTime < mentorData.timezone.endTime;
   const isFormValid =
     mentorData.introduction.title.trim().length > 0 &&
     mentorData.introduction.content.trim().length > 0 &&
-    mentorData.mentoringField.length > 0; // 멘토링 분야 선택 필수
+    mentorData.mentoringField.length > 0 && // 멘토링 분야 선택 필수
+    isTimezoneValid;
 
   return (
     <div className="flex flex-col w-full h-[calc(100vh-15vh)] overflow-hidden">

--- a/src/user/components/profile/mentor/MentorTime.tsx
+++ b/src/user/components/profile/mentor/MentorTime.tsx
@@ -50,14 +50,23 @@ const MentorTime = ({ mentorData, setMentorData }: MentorTimeProps) => {
 
   // 시간 선택 완료 후 mentorData 업데이트
   const handleTimeSave = () => {
+    const start = `${String(startHour).padStart(2, '0')}:${String(startMinute).padStart(2, '0')}:00`;
+    const end = `${String(endHour).padStart(2, '0')}:${String(endMinute).padStart(2, '0')}:00`;
+
+    if (start >= end) {
+      alert('시작 시간은 종료 시간보다 빨라야 합니다.');
+      return;
+    }
+
     setMentorData((prev) => ({
       ...prev,
       timezone: {
         ...prev.timezone,
-        startTime: `${String(startHour).padStart(2, '0')}:${String(startMinute).padStart(2, '0')}:00`,
-        endTime: `${String(endHour).padStart(2, '0')}:${String(endMinute).padStart(2, '0')}:00`,
+        startTime: start,
+        endTime: end,
       },
     }));
+
     setIsModalOpen(false);
   };
 

--- a/src/user/pages/MenteeProfileRegistration.tsx
+++ b/src/user/pages/MenteeProfileRegistration.tsx
@@ -20,16 +20,7 @@ export default function MenteeProfileRegistration() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
 
-  const handleNext = async () => {
-    if (step === 1) {
-      try {
-        await createMenteeProfile(menteeData);
-      } catch (error) {
-        console.error('❌ 멘티 프로필 전송 실패:', error);
-        alert('멘티 프로필 저장에 실패했습니다.');
-        return;
-      }
-    }
+  const handleNext = () => {
     setStep((prev) => prev + 1);
   };
 
@@ -43,12 +34,17 @@ export default function MenteeProfileRegistration() {
 
     setIsUploading(true);
     try {
+      // 멘티 프로필 저장
+      await createMenteeProfile(menteeData);
+
+      // 인증서 업로드
       await uploadMenteeCertificate(selectedFile, 'ENROLLMENT');
-      alert('멘티 인증서 업로드가 완료되었습니다! 프로필 등록이 끝났습니다!');
+
+      alert('멘티 프로필과 인증서 등록이 완료되었습니다!');
       navigate('/user');
     } catch (error) {
-      console.error('❌ 멘티 인증서 업로드 실패:', error);
-      alert('멘티 인증서 업로드에 실패했습니다.');
+      console.error('❌ 프로필 또는 인증서 업로드 실패:', error);
+      alert('프로필 또는 인증서 업로드에 실패했습니다.');
     } finally {
       setIsUploading(false);
     }

--- a/src/user/pages/MentorProfileRegistration.tsx
+++ b/src/user/pages/MentorProfileRegistration.tsx
@@ -30,17 +30,7 @@ export default function MentorProfileRegistration() {
   });
 
   // 다음 단계로 이동
-  const handleNext = async () => {
-    if (step === 3) {
-      try {
-        console.log('mentorData 전송:', JSON.stringify(mentorData, null, 2));
-        await createMentorProfile(mentorData);
-      } catch (error) {
-        console.error('❌ 멘토 프로필 전송 실패:', error);
-        alert('멘토 프로필 저장에 실패했습니다.');
-        return;
-      }
-    }
+  const handleNext = () => {
     setStep((prev) => prev + 1);
   };
 
@@ -50,7 +40,9 @@ export default function MentorProfileRegistration() {
     certification: File | null;
   }) => {
     try {
-      //console.log('멘토 인증서 파일 전송:', files);
+      // 멘토 프로필 먼저 저장
+      console.log('멘토 프로필 전송:', JSON.stringify(mentorData, null, 2));
+      await createMentorProfile(mentorData);
 
       // 학력 인증 업로드
       if (files.enrollment) {
@@ -62,11 +54,11 @@ export default function MentorProfileRegistration() {
         await uploadMentorCertificate(files.certification, 'EMPLOYMENT');
       }
 
-      alert('멘토 등록이 완료되었습니다!');
+      alert('멘토 프로필 및 인증서 등록이 완료되었습니다!');
       navigate('/user'); // 완료 후 마이페이지 이동
     } catch (error) {
-      console.error('❌ 멘토 인증서 업로드 실패:', error);
-      alert('멘토 인증서 업로드에 실패했습니다.');
+      console.error('❌ 프로필 또는 인증서 업로드 실패:', error);
+      alert('프로필 또는 인증서 업로드에 실패했습니다.');
     }
   };
 


### PR DESCRIPTION
## ✨ 구현한 기능
- 프로필 등록 여부 확인 API 호출:useEffect를 사용하여 컴포넌트 마운트 시 API 요청을 통해 현재 사용자의 프로필 등록 여부를 확인
  - 프로필이 이미 등록된 경우, onNext()를 호출하여 인증 단계로 즉시 이동하도록 처리.
- 중복 등록 방지 로직 추가:
  - 뒤로 가기 후 다시 프로필 등록 페이지에 접근해도 기존 프로필이 존재하는 경우 등록 과정을 건너뛰고 다음 단계로 이동하도록 수정
- 에러 핸들링 개선:
  - 네트워크 오류 또는 서버 응답 문제 발생 시 적절한 에러 메시지를 표시하도록 개선.

## 📢 논의하고 싶은 내용
- 뒤로 가기를 눌렀을 때 인증 단계로 다시 돌아가는 UX가 사용자 입장에서 혼란을 줄 수 있는지 논의.

## 🎸 기타
- 기존 코드에서 isFormValid 검증 로직이 일부 개선됨.
- API 호출 관련 로직을 useEffect에서 처리하면서, useState를 최소화하여 성능 최적화.
